### PR TITLE
FF1PR: Entrance hints

### DIFF
--- a/worlds/ff1pr/__init__.py
+++ b/worlds/ff1pr/__init__.py
@@ -9,7 +9,7 @@ from .options import FF1pixelOptions, grouped_options, presets
 from .entrances import global_entrances, EntranceData, EntGroup
 from .ef_shuffle import shuffle_entrances
 from .data import itemnames
-from .spoiler import generate_entrances_spoiler
+from .spoiler import generate_entrance_hints_and_spoiler
 from Utils import visualize_regions
 
 GAME_NAME: str = "FF1 Pixel Remaster"
@@ -56,8 +56,12 @@ class FF1pixelWorld(World):
     result_entrances: Dict[str, str] = {}
     region_dict: Dict[str, Dict[str, str]] = {}
 
-    spawn_airship = False
-    spawn_ship = False
+    def __init__(self, multiworld: MultiWorld, player: int):
+        super().__init__(multiworld, player)
+        self.spawn_airship = False
+        self.spawn_ship = False
+        self.hint_data = {}
+        self.spoiler_text = ""
 
     def generate_early(self) -> None:
         if self.options.start_inventory.value.get("Airship", 0) > 0:
@@ -169,6 +173,11 @@ class FF1pixelWorld(World):
             location = FF1pixelLocation(self.player, location_name, None, region)
             region.locations.append(location)
 
+        if self.options.shuffle_towns > 0 or \
+                self.options.shuffle_overworld or \
+                self.options.shuffle_entrances > 0:
+            self.hint_data, self.spoiler_text = generate_entrance_hints_and_spoiler(self)
+
     def set_rules(self) -> None:
         set_region_rules(self)
         set_location_rules(self)
@@ -182,13 +191,14 @@ class FF1pixelWorld(World):
         progitempool.sort(
                 key=lambda item: 1 if (itemnames.lute_tablature in item.name and item.game == GAME_NAME) else 0)
 
+    def extend_hint_information(self, hint_data):
+        if self.hint_data:
+            hint_data[self.player] = self.hint_data
+
     def write_spoiler(self, spoiler_handle: TextIO) -> None:
-        if self.options.shuffle_towns > 0 or \
-            self.options.shuffle_overworld or \
-            self.options.shuffle_entrances > 0:
-            spoiler_text = generate_entrances_spoiler(self)
+        if self.spoiler_text:
             spoiler_handle.writelines(f"\nFF1 Pixel Remaster entrances layout for {self.multiworld.player_name[self.player]}\n")
-            spoiler_handle.writelines(spoiler_text)
+            spoiler_handle.writelines(self.spoiler_text)
 
     def fill_slot_data(self) -> Dict[str, Any]:
         options_list = presets["Starter"].keys()

--- a/worlds/ff1pr/spoiler.py
+++ b/worlds/ff1pr/spoiler.py
@@ -1,12 +1,13 @@
-from typing import Dict, List, Any, NamedTuple, TextIO, TYPE_CHECKING
+from typing import Dict, List, Any, NamedTuple, TextIO, Optional, TYPE_CHECKING
 from .regions import overworld_regions
 if TYPE_CHECKING:
     from . import FF1pixelWorld, FF1pixelOptions
 
-def generate_entrances_spoiler(world: "FF1pixelWorld") -> str:
+def generate_entrance_hints_and_spoiler(world: "FF1pixelWorld") -> str:
     all_regions = world.multiworld.regions.region_cache[world.player]
+    entrance_hint_data: Dict[int, str] = {}
 
-    def visit_region(next_region: str, depth: int, depths: List[bool]) -> str:
+    def visit_region(next_region: str, depth: int, depths: List[bool], current_entrance: Optional[str]) -> str:
         spoiler_text: str = ""
 
         indent = ""
@@ -25,6 +26,12 @@ def generate_entrances_spoiler(world: "FF1pixelWorld") -> str:
         if depth == 0: spoiler_text += f"[{next_region}]\n"
         if depth > 0: spoiler_text += f"{indent}{next_region}\n"
 
+        if current_entrance is not None:
+            crawled_region = all_regions[next_region]
+            for location in crawled_region.locations:
+                if location.address:
+                    entrance_hint_data[location.address] = current_entrance.split("Overworld - ")[-1]
+
         crawled_region = all_regions[next_region]
         exits_to_crawl = [e for e in crawled_region.exits if e.connected_region.name not in overworld_regions]
         exit_count = len(exits_to_crawl)
@@ -36,16 +43,20 @@ def generate_entrances_spoiler(world: "FF1pixelWorld") -> str:
                 else: depths[depth + 1] = False
             current_count += 1
 
-            if depth == 0: spoiler_text += f" >{crawled_exit.name}\n"
-            spoiler_text += visit_region(crawled_exit.connected_region.name, depth + 1, depths)
-            if depth == 0: spoiler_text += "\n"
+            # At depth 0, this exit's name becomes the "entrance" label for everything reachable under it.
+            if depth == 0:
+                spoiler_text += f" >{crawled_exit.name}\n"
+                spoiler_text += visit_region(crawled_exit.connected_region.name, depth + 1, depths, crawled_exit.name)
+                spoiler_text += "\n"
+            else:
+                spoiler_text += visit_region(crawled_exit.connected_region.name, depth + 1, depths, current_entrance)
 
         if depth == 0 and exit_count == 0: spoiler_text += "\n"
         return spoiler_text
 
     entrances_spoiler: str = ""
     for ow_region in overworld_regions:
-        false_depth = [False for i in range(0, 20)]
-        entrances_spoiler += visit_region(ow_region, 0, false_depth)
+        false_depth = [False for _ in range(20)]
+        entrances_spoiler += visit_region(ow_region, 0, false_depth, current_entrance=None)
 
-    return entrances_spoiler
+    return entrance_hint_data, entrances_spoiler


### PR DESCRIPTION
## What is this fixing or adding?
Adds entrance hints, so that hints will show which entrance a location is at when entrance shuffle is on.

I moved `generate_entrances_spoiler` to an earlier stage and have it build entrance hints at the same time, storing hint data and spoiler text to be used later on.

## How was this tested?
Generated a game, opened spoiler log, ran `!hint Everything`, checked that it was showing the correct entrance. Example:

Spoiler log:
```
 >Overworld - Elven Castle
  ╚>Mount Gulg B3 (Maze)
    ╚>Dragon Caves (Forest)
```

Server output for hint:
```
Notice (Team #1): [Hint]: Player1's Leather Shield is at Dragon Caves (Forest) - West Room 3 in Player1's World at Elven Castle. (priority)
```